### PR TITLE
Remove clj-parent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,7 @@
+(def kitchensink-version "3.5.3")
+(def trapperkeeper-version "4.3.0")
+(def i18n-version "1.0.2")
+
 (defproject org.openvoxproject/trapperkeeper-status "1.3.1-SNAPSHOT"
   :description "A trapperkeeper service for getting the status of other trapperkeeper services."
   :url "https://github.com/openvoxproject/trapperkeeper-status"
@@ -6,26 +10,39 @@
 
   :min-lein-version "2.9.0"
 
-  :parent-project {:coords [org.openvoxproject/clj-parent "7.6.3"]
-                   :inherit [:managed-dependencies]}
-
   :pedantic? :abort
 
+  ;; These are to enforce consistent versions across dependencies of dependencies,
+  ;; and to avoid having to define versions in multiple places. If a component
+  ;; defined under :dependencies ends up causing an error due to :pedantic? :abort,
+  ;; because it is a dep of a dep with a different version, move it here.
+  :managed-dependencies [[org.clojure/clojure "1.12.4"]
+
+                         [ring/ring-codec "1.1.2"]
+                         [commons-codec "1.15"]
+
+                         [org.bouncycastle/bcpkix-jdk18on "1.83"]
+  
+                         [org.openvoxproject/kitchensink ~kitchensink-version]
+                         [org.openvoxproject/kitchensink ~kitchensink-version :classifier "test"]
+                         [org.openvoxproject/trapperkeeper ~trapperkeeper-version]
+                         [org.openvoxproject/trapperkeeper ~trapperkeeper-version :classifier "test"]]
+
   :dependencies [[org.clojure/clojure]
-                 [cheshire]
-                 [slingshot]
-                 [prismatic/schema]
-                 [trptcolin/versioneer]
-                 [org.apache.httpcomponents/httpasyncclient]
-                 [org.clojure/java.jmx]
-                 [org.clojure/tools.logging]
+                 [cheshire "5.10.2"]
+                 [slingshot "0.12.2"]
+                 [prismatic/schema "1.1.12"]
+                 [trptcolin/versioneer "0.2.0"]
+                 [org.apache.httpcomponents/httpasyncclient "4.1.5"]
+                 [org.clojure/java.jmx "1.0.0"]
+                 [org.clojure/tools.logging "1.2.4"]
                  [org.openvoxproject/kitchensink]
                  [org.openvoxproject/trapperkeeper]
-                 [org.openvoxproject/trapperkeeper-scheduler]
-                 [org.openvoxproject/ring-middleware]
-                 [org.openvoxproject/comidi]
-                 [org.openvoxproject/i18n]
-                 [org.openvoxproject/trapperkeeper-authorization]]
+                 [org.openvoxproject/trapperkeeper-scheduler "1.3.0"]
+                 [org.openvoxproject/ring-middleware "2.1.0"]
+                 [org.openvoxproject/comidi "1.1.1"]
+                 [org.openvoxproject/i18n ~i18n-version]
+                 [org.openvoxproject/trapperkeeper-authorization "2.1.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/CLOJARS_USERNAME
@@ -33,10 +50,9 @@
                                      :sign-releases false}]]
 
   :profiles {:dev {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
-                                  [org.openvoxproject/http-client]
+                                  [org.openvoxproject/http-client "2.2.0"]
                                   [org.openvoxproject/trapperkeeper :classifier "test"]
-                                  [org.openvoxproject/trapperkeeper-webserver-jetty10]
+                                  [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.0"]
                                   [org.openvoxproject/kitchensink :classifier "test"]]}}
 
-  :plugins [[lein-parent "0.3.9"]
-            [org.openvoxproject/i18n "1.0.2" :hooks false]])
+  :plugins [[org.openvoxproject/i18n ~i18n-version :hooks false]])


### PR DESCRIPTION
In an effort to simplify our projects, this removes clj-parent and specifies dependency versions directly. Since we only have two top-level components (openvox-server and openvoxdb) and we use renovate to keep dependencies up to date, this introduces less churn and coordination when dependencies need updating.