### PR TITLE
Migrate config to use trapperkeeper-webserver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def i18n-version "1.0.4")
 
-(defproject org.openvoxproject/trapperkeeper-status "1.3.6-SNAPSHOT"
+(defproject org.openvoxproject/trapperkeeper-status "1.4.0-SNAPSHOT"
   :description "A trapperkeeper service for getting the status of other trapperkeeper services."
   :url "https://github.com/openvoxproject/trapperkeeper-status"
   :license {:name "Apache License, Version 2.0"
@@ -40,7 +40,7 @@
                          [org.openvoxproject/trapperkeeper "4.3.5" :classifier "test"]
                          [org.openvoxproject/trapperkeeper-authorization "2.1.9"]
                          [org.openvoxproject/trapperkeeper-scheduler "1.3.2"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8"]]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0"]]
 
   :dependencies [[org.clojure/clojure]
                  [cheshire]
@@ -67,6 +67,6 @@
                                   [org.openvoxproject/http-client]
                                   [org.openvoxproject/kitchensink :classifier "test"]
                                   [org.openvoxproject/trapperkeeper :classifier "test"]
-                                  [org.openvoxproject/trapperkeeper-webserver-jetty10]]}}
+                                  [org.openvoxproject/trapperkeeper-webserver]]}}
 
   :plugins [[org.openvoxproject/i18n ~i18n-version :hooks false]])

--- a/test/puppetlabs/trapperkeeper/services/status/status_proxy_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_proxy_service_test.clj
@@ -10,7 +10,7 @@
     [puppetlabs.trapperkeeper.services.status.status-proxy-service :refer [status-proxy-service]]
     [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting-service]
     [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as scheduler-service]
-    [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10-service]))
+    [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty-service]))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -55,7 +55,7 @@
     ; Start status service
     (with-app-with-config
       status-app
-      [jetty10-service/jetty10-service
+      [jetty-service/jetty-service
        webrouting-service/webrouting-service
        status-service
        foo-service
@@ -65,7 +65,7 @@
       ; Start the proxy service
       (with-app-with-config
         proxy-app
-        [jetty10-service/jetty10-service
+        [jetty-service/jetty-service
          webrouting-service/webrouting-service
          status-proxy-service]
         status-proxy-service-config
@@ -149,7 +149,7 @@
       (with-app-with-config
         ; Start status service
         status-app
-        [jetty10-service/jetty10-service
+        [jetty-service/jetty-service
          webrouting-service/webrouting-service
          status-service
          scheduler-service/scheduler-service
@@ -158,7 +158,7 @@
         ; Start the proxy service
         (with-app-with-config
           proxy-app
-          [jetty10-service/jetty10-service
+          [jetty-service/jetty-service
            webrouting-service/webrouting-service
            status-proxy-service]
           status-proxy-service-config
@@ -182,7 +182,7 @@
             (with-test-logging
               (with-app-with-config
                 proxy-app
-                [jetty10-service/jetty10-service
+                [jetty-service/jetty-service
                  webrouting-service/webrouting-service
                  status-proxy-service]
                 bad-config))))))
@@ -197,7 +197,7 @@
             (with-test-logging
               (with-app-with-config
                 proxy-app
-                [jetty10-service/jetty10-service
+                [jetty-service/jetty-service
                  webrouting-service/webrouting-service
                  status-proxy-service]
                 bad-config))))))
@@ -212,7 +212,7 @@
             (with-test-logging
               (with-app-with-config
                 proxy-app
-                [jetty10-service/jetty10-service
+                [jetty-service/jetty-service
                  webrouting-service/webrouting-service
                  status-proxy-service]
                 bad-config)))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -11,7 +11,7 @@
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting-service]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as tk-auth]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10-service]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty-service]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as scheduler-service]
             [puppetlabs.kitchensink.core :as ks]))
 
@@ -47,13 +47,13 @@
   (:status (parse-response resp true)))
 
 (defmacro with-status-service-with-config
-  "Macro to start the status service and its dependencies (jetty10 and
+  "Macro to start the status service and its dependencies (jetty and
   webrouting service), along with any other services desired, with the given
   config"
   [app services config & body]
   `(with-app-with-config
      ~app
-     (concat [jetty10-service/jetty10-service
+     (concat [jetty-service/jetty-service
               webrouting-service/webrouting-service
               scheduler-service/scheduler-service
               status-service] ~services)
@@ -61,7 +61,7 @@
      (do ~@body)))
 
 (defmacro with-status-service
-  "Macro to start the status service and its dependencies (jetty10 and
+  "Macro to start the status service and its dependencies (jetty and
   webrouting service), along with any other services desired. Provides
   a default tk config"
   [app services & body]
@@ -126,7 +126,7 @@
 
 (deftest get-status-test
   (with-status-service app [foo-service
-                            jetty10-service/jetty10-service
+                            jetty-service/jetty-service
                             webrouting-service/webrouting-service
                             status-service]
     (let [svc (get-service app :StatusService)]
@@ -198,7 +198,7 @@
   (testing "can mount status endpoint at alternate location"
     (with-app-with-config
       app
-      [jetty10-service/jetty10-service
+      [jetty-service/jetty-service
        webrouting-service/webrouting-service
        scheduler-service/scheduler-service
        status-service]
@@ -211,7 +211,7 @@
   (testing "with auth service running and cert auth enabled for endpoint"
     (with-app-with-config
       app
-      [jetty10-service/jetty10-service
+      [jetty-service/jetty-service
        webrouting-service/webrouting-service
        scheduler-service/scheduler-service
        status-service
@@ -236,7 +236,7 @@
   (testing "with auth service running and cert auth disabled for endpoint"
     (with-app-with-config
       app
-      [jetty10-service/jetty10-service
+      [jetty-service/jetty-service
        webrouting-service/webrouting-service
        scheduler-service/scheduler-service
        status-service


### PR DESCRIPTION
We removed the 'Jetty10' from the repo and component name, as well as classes and service names.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
